### PR TITLE
Deduplication

### DIFF
--- a/src/Chat.fs
+++ b/src/Chat.fs
@@ -436,7 +436,7 @@ module Chat =
         | DisconnectClient socket ->
             let connections =
                 model.Connections
-                |> List.where (fun o -> o.ConnectionId <> socket.RemoteEndPoint.ToString())
+                |> List.where (fun o -> socket.RemoteEndPoint <> null && o.ConnectionId <> socket.RemoteEndPoint.ToString())
                 
             socket.Dispose()
             

--- a/src/Chat.fs
+++ b/src/Chat.fs
@@ -542,7 +542,7 @@ module Chat =
             logger.Debug $"[RemoteChatMessageReceived] Chat message {msg} package received by {client.RemoteEndPoint}"
             
             let retranslatedByCurrentInstance = msg.RetranslationInfo.RetranslatedBy |> List.contains model.UserId
-            let receivedMessageAlreadyPresentsHere = model.MessagesListHashSet |> Set.contains (msg.GetHashCode())
+            let receivedMessageAlreadyPresentsHere = model.MessagesListHashSet |> Set.contains (msg.GetHalfHashCode())
             
             if retranslatedByCurrentInstance || receivedMessageAlreadyPresentsHere
             then
@@ -593,7 +593,7 @@ module Chat =
             let model = {
                 model with
                     MessagesList = model.MessagesList @ [m]
-                    MessagesListHashSet = model.MessagesListHashSet |> Set.add (m.GetHashCode())
+                    MessagesListHashSet = model.MessagesListHashSet |> Set.add (m.Message.GetHalfHashCode())
                     ChatScrollViewOffset = verticalOffset
             }
             model, Cmd.ofMsg msg

--- a/src/Message.fs
+++ b/src/Message.fs
@@ -14,12 +14,15 @@ module Message =
         RetranslationInfo: RetranslationInfo
     }
     
-    type ChatMessage = {
+    type ChatMessage =
+        {
         MessageText: string
         MessageSender: string
         DateTime: DateTime
         SecretCode: int
         UserId: string
         RetranslationInfo: RetranslationInfo
-    }
+        }
+        
+        member this.GetHalfHashCode() = hash <| this.MessageText + this.UserId + this.DateTime.Ticks.ToString() + this.SecretCode.ToString()
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Duplication and bad topology fix (#2)
- Minor exception handling improvements

### :arrow_heading_down: What is the current behavior?
1. When you start application instance no matter if this app instance bounded to tcp listener or not - current app instance connects to remote known peers and all local peers
2. If three app instances knows about each other and sending messages to each other - then messages duplication appears.

### :new: What is the new behavior (if this is a feature change)?
1. Application connects to known peers only if it bounded to tcp listener.
2. Deduplication applying when receiving message duplicate

### :boom: Does this PR introduce a breaking change?
Yes, because network topology was changed.